### PR TITLE
Add equirectangular UV mapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: node_js
 node_js:
-  - "8"
-  - "node"
+  - "10"

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
-export default function icomesh(order = 4) {
+export default function icomesh(order = 4, uvMap = false) {
     if (order > 10) throw new Error(`Max order is 10, but given ${order}.`);
 
     // set up an icosahedron (12 vertices / 20 triangles)
     const f = (1 + Math.sqrt(5)) / 2;
     const T = Math.pow(4, order);
 
-    const vertices = new Float32Array((10 * T + 2) * 3);
+    const numVertices = 10 * T + 2;
+    const numDuplicates = !uvMap ? 0 : order === 0 ? 3 : Math.pow(2, order) * 3 + 9;
+
+    const vertices = new Float32Array((numVertices + numDuplicates) * 3);
     vertices.set(Float32Array.of(
         -1, f, 0, 1, f, 0, -1, -f, 0, 1, -f, 0,
         0, -1, f, 0, 1, f, 0, -1, -f, 0, 1, -f,
@@ -24,7 +27,7 @@ export default function icomesh(order = 4) {
 
     function addMidPoint(a, b) {
         const key = Math.floor(((a + b) * (a + b + 1) / 2) + Math.min(a, b)); // Cantor's pairing function
-        let i = midCache.get(key);
+        const i = midCache.get(key);
         if (i !== undefined) {
             midCache.delete(key); // midpoint is only reused once, so we delete it for performance
             return i;
@@ -33,8 +36,7 @@ export default function icomesh(order = 4) {
         vertices[3 * v + 0] = (vertices[3 * a + 0] + vertices[3 * b + 0]) * 0.5;
         vertices[3 * v + 1] = (vertices[3 * a + 1] + vertices[3 * b + 1]) * 0.5;
         vertices[3 * v + 2] = (vertices[3 * a + 2] + vertices[3 * b + 2]) * 0.5;
-        i = v++;
-        return i;
+        return v++;
     }
 
     let trianglesPrev = triangles;
@@ -61,7 +63,7 @@ export default function icomesh(order = 4) {
     }
 
     // normalize vertices
-    for (let i = 0, len = vertices.length; i < len; i += 3) {
+    for (let i = 0; i < numVertices * 3; i += 3) {
         const v1 = vertices[i + 0];
         const v2 = vertices[i + 1];
         const v3 = vertices[i + 2];
@@ -71,5 +73,67 @@ export default function icomesh(order = 4) {
         vertices[i + 2] *= m;
     }
 
-    return {vertices, triangles};
+    if (!uvMap) return {vertices, triangles};
+
+    // uv mapping
+    const uv = new Float32Array((numVertices + numDuplicates) * 2);
+    for (let i = 0; i < numVertices; i++) {
+        uv[2 * i + 0] = Math.atan2(vertices[3 * i + 2], vertices[3 * i]) / (2 * Math.PI) + 0.5;
+        uv[2 * i + 1] = Math.asin(vertices[3 * i + 1]) / Math.PI + 0.5;
+    }
+
+    const duplicates = new Map();
+
+    function addDuplicate(i, uvx, uvy, cached) {
+        if (cached) {
+            const dupe = duplicates.get(i);
+            if (dupe !== undefined) return dupe;
+        }
+        vertices[3 * v + 0] = vertices[3 * i + 0];
+        vertices[3 * v + 1] = vertices[3 * i + 1];
+        vertices[3 * v + 2] = vertices[3 * i + 2];
+        uv[2 * v + 0] = uvx;
+        uv[2 * v + 1] = uvy;
+        if (cached) duplicates.set(i, v);
+        return v++;
+    }
+
+    for (let i = 0; i < triangles.length; i += 3) {
+        const a = triangles[i + 0];
+        const b = triangles[i + 1];
+        const c = triangles[i + 2];
+        let ax = uv[2 * a];
+        let bx = uv[2 * b];
+        let cx = uv[2 * c];
+        const ay = uv[2 * a + 1];
+        const by = uv[2 * b + 1];
+        const cy = uv[2 * c + 1];
+
+        // uv fixing code; don't ask me how I got here
+        if (bx - ax >= 0.5 && ay !== 1) bx -= 1;
+        if (cx - bx > 0.5) cx -= 1;
+        if (ax > 0.5 && ax - cx > 0.5 || ax === 1 && cy === 0) ax -= 1;
+        if (bx > 0.5 && bx - ax > 0.5) bx -= 1;
+
+        if (ay === 0 || ay === 1) {
+            ax = (bx + cx) / 2;
+            if (ay === bx) uv[2 * a] = ax;
+            else triangles[i + 0] = addDuplicate(a, ax, ay, false);
+
+        } else if (by === 0 || by === 1) {
+            bx = (ax + cx) / 2;
+            if (by === ax) uv[2 * b] = bx;
+            else triangles[i + 1] = addDuplicate(b, bx, by, false);
+
+        } else if (cy === 0 || cy === 1) {
+            cx = (ax + bx) / 2;
+            if (cy === ax) uv[2 * c] = cx;
+            else triangles[i + 2] = addDuplicate(c, cx, cy, false);
+        }
+        if (ax !== uv[2 * a] && ay !== 0 && ay !== 1) triangles[i + 0] = addDuplicate(a, ax, ay, true);
+        if (bx !== uv[2 * b] && by !== 0 && by !== 1) triangles[i + 1] = addDuplicate(b, bx, by, true);
+        if (cx !== uv[2 * c] && cy !== 0 && cy !== 1) triangles[i + 2] = addDuplicate(c, cx, cy, true);
+    }
+
+    return {vertices, triangles, uv};
 }

--- a/test.js
+++ b/test.js
@@ -2,23 +2,41 @@
 import test from 'tape';
 import icomesh from './index.js';
 
+const x = 0.525731086730957;
+const y = 0.8506507873535156;
+
 test('icomesh 0', (t) => {
     const {vertices, triangles} = icomesh(0);
-    const x = 0.525731086730957;
-    const y = 0.8506507873535156;
+
+    t.ok(triangles instanceof Uint16Array);
+    t.ok(vertices instanceof Float32Array);
 
     t.same(vertices, [
         -x, y, 0, x, y, 0, -x, -y, 0, x, -y, 0, 0, -x, y, 0, x, y,
         0, -x, -y, 0, x, -y, y, 0, -x, y, 0, x, -y, 0, -x, -y, 0, x
     ]);
-    t.ok(triangles instanceof Uint16Array);
-
     t.same(triangles, [
         0, 11, 5, 0, 5, 1, 0, 1, 7, 0, 7, 10, 0, 10, 11, 11, 10, 2,
         5, 11, 4, 1, 5, 9, 7, 1, 8, 10, 7, 6, 3, 9, 4, 3, 4, 2,
         3, 2, 6, 3, 6, 8, 3, 8, 9, 9, 8, 1, 4, 9, 5, 2, 4, 11, 6, 2, 10, 8, 6, 7
     ]);
-    t.ok(vertices instanceof Float32Array);
+
+    t.end();
+});
+
+test('icomesh 0 uvmap', (t) => {
+    const {vertices, triangles} = icomesh(0, true);
+
+    t.same(Array.from(vertices), [
+        -x, y, 0, x, y, 0, -x, -y, 0, x, -y, 0, 0, -x, y, 0, x, y,
+        0, -x, -y, 0, x, -y, y, 0, -x, y, 0, x, -y, 0, -x, -y, 0, x,
+        -x, y, 0, -y, 0, x, -x, -y, 0
+    ]);
+    t.same(Array.from(triangles), [
+        0, 11, 5, 0, 5, 1, 12, 1, 7, 12, 7, 10, 12, 10, 13, 13, 10, 14, 5,
+        11, 4, 1, 5, 9, 7, 1, 8, 10, 7, 6, 3, 9, 4, 3, 4, 2, 3, 14, 6, 3,
+        6, 8, 3, 8, 9, 9, 8, 1, 4, 9, 5, 2, 4, 11, 6, 14, 10, 8, 6, 7
+    ]);
 
     t.end();
 });


### PR DESCRIPTION
Closes #4. Turned out to be much trickier than I thought, but seems to work correctly. Unfortunately it's a 30% performance hit, and not everyone needs equirectangular uvs, so it's disabled by default (`icomesh(order, true)` to generate). @MaxGraey anything I missed in terms of performance?